### PR TITLE
Aumento de cobertura de testes

### DIFF
--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"log"
 	"regexp"
 )
 
@@ -10,12 +9,8 @@ func RemoveSpecialCharacters(text string) string {
 		return "Empty text"
 	}
 
-	re, err := regexp.Compile(`[^\w]`)
-	if err != nil {
-		log.Fatal(err)
-		return "Invalid text"
-	}
-	text = re.ReplaceAllString(text, " ")
+	//Expression here is fixed. There is no reason to check err
+	re, _ := regexp.Compile(`[^\w\s]`)
+	text = re.ReplaceAllString(text, "")
 	return text
-
 }

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -9,8 +9,7 @@ func RemoveSpecialCharacters(text string) string {
 		return "Empty text"
 	}
 
-	//Expression here is fixed. There is no reason to check err
-	re, _ := regexp.Compile(`[^\w\s]`)
+	re := regexp.MustCompile(`[^\w\s]`)
 	text = re.ReplaceAllString(text, "")
 	return text
 }

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -7,7 +7,13 @@ import (
 )
 
 var _ = Describe("Utils", func() {
-	It("Should return 'Empty text' where there is no arguments", func() {
+
+	It("Should return 'Empty text' when there is no arguments", func() {
 		Expect(utils.RemoveSpecialCharacters("")).To(Equal("Empty text"))
 	})
+
+	It("Should return 'Expected text' when argument is '[-!,Expected*)@#%( text&$_?.^' ", func() {
+		Expect(utils.RemoveSpecialCharacters("[-!,Expected*)@#%( text&$?.^")).To(Equal("Expected text"))
+	})
+
 })


### PR DESCRIPTION
### Descrição
- Implementação de testes para cobrir o restante do método `RemoveSpecialCharacters`

### Motivação
- Melhorar a cobertura de testes

### Resumo
-  Implementado testes para cobrir as duas possibilidades de retorno do método `RemoveSpecialCharacters`
- O tratamento de exceção em caso de Expressão inválida foi removida por não fazer sentido, pois a expressão está fixada.
- De acordo com o `gocritc` é preferível a utilização do `MustCompile` ao invés de `Compile`